### PR TITLE
Better config, currency support and an amount of doors allow to be owned

### DIFF
--- a/lua/autorun/client/cl_door_config.lua
+++ b/lua/autorun/client/cl_door_config.lua
@@ -17,3 +17,7 @@ Door_System_Config.AllowedDoors = {
 	["func_door"] = true,
 	["func_door_rotating"] = true
 }
+
+
+Door_System_Config.ShowDoorHealth = true -- Show the door health. 
+		-- This is only useful if you have a door health addon like "Destructible Doors for Gmod!"

--- a/lua/autorun/client/cl_door_config.lua
+++ b/lua/autorun/client/cl_door_config.lua
@@ -1,3 +1,4 @@
+Door_System_Config = {}
 
 CreateClientConVar( "DoorKey", KEY_F9, true, false, "Key that you press to access the menu of a door." )
 
@@ -9,3 +10,10 @@ hook.Add( "PopulateToolMenu", "DoorConfig", function()
 		} )
 	end )
 end )
+
+Door_System_Config.AllowedDoors = {
+	["prop_door"] = true,
+	["prop_door_rotating"] = true,
+	["func_door"] = true,
+	["func_door_rotating"] = true
+}

--- a/lua/autorun/client/cl_door_config.lua
+++ b/lua/autorun/client/cl_door_config.lua
@@ -19,5 +19,5 @@ Door_System_Config.AllowedDoors = {
 }
 
 
-Door_System_Config.ShowDoorHealth = true -- Show the door health. 
+Door_System_Config.ShowDoorHealth = false -- Show the door health. 
 		-- This is only useful if you have a door health addon like "Destructible Doors for Gmod!"

--- a/lua/autorun/client/cl_doors.lua
+++ b/lua/autorun/client/cl_doors.lua
@@ -5,13 +5,6 @@ surface.CreateFont( "DoorFont", {
 	weight = 1000
 } )
 
-local allowed = {
-	["prop_door"] = true,
-	["prop_door_rotating"] = true,
-	["func_door"] = true,
-	["func_door_rotating"] = true
-}
-
 local distance = DOOR_CONFIG_DISTANCE * DOOR_CONFIG_DISTANCE
 local OpenDoorMenuAdmin, OpenDoorMenu
 
@@ -376,7 +369,7 @@ hook.Add( "HUDPaint", "DoorHUD", function()
 	local entindex = ent:EntIndex()
 	local keyname = language.GetPhrase( input.GetKeyName( GetConVar( "DoorKey" ):GetInt() ) )
 	if ply.MenuOpen then return end
-	if IsValid( ent ) and ply:GetPos():DistToSqr( ent:GetPos() ) < distance and allowed[ent:GetClass()] then
+	if IsValid( ent ) and ply:GetPos():DistToSqr( ent:GetPos() ) < distance and Door_System_Config.AllowedDoors[ent:GetClass()] then
 		if doorname != "" then
 			draw.SimpleText( doorname, "DoorFont", ScrW() / 2, ScrH() / 2 - 20, DOOR_CONFIG_NAME_COLOR, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
 		end
@@ -404,7 +397,7 @@ hook.Add( "PlayerButtonDown", "DoorButtons", function( ply, button )
 	local doorkey = GetConVar( "DoorKey" ):GetInt()
 	local ent = ply:GetEyeTrace().Entity
 	if !IsFirstTimePredicted() or ply.MenuOpen then return end
-	if IsValid( ent ) and button == doorkey and ply:GetPos():DistToSqr( ent:GetPos() ) < distance and allowed[ent:GetClass()] then
+	if IsValid( ent ) and button == doorkey and ply:GetPos():DistToSqr( ent:GetPos() ) < distance and Door_System_Config.AllowedDoors[ent:GetClass()] then
 		CheckMenuAccess( ply, ent )
 	end
 end )

--- a/lua/autorun/client/cl_doors.lua
+++ b/lua/autorun/client/cl_doors.lua
@@ -52,7 +52,7 @@ local function SetDoorName( ply, door )
 end
 
 local function CheckMenuAccess( ply, door )
-	if ply:IsSuperAdmin() or ( ply:IsAdmin() and DOOR_CONFIG_ALLOW_ADMIN ) then
+	if DOOR_CONFIG_ADMIN_RANKS[ply:GetUserGroup()] then
 		OpenDoorMenuAdmin( ply, door )
 	else
 		OpenDoorMenu( ply, door )
@@ -387,6 +387,7 @@ hook.Add( "HUDPaint", "DoorHUD", function()
 			end
 		end
 		draw.SimpleText( "Press "..keyname.." for door options.", "DoorFont", ScrW() / 2, ScrH() / 2 + 20, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
+		if Door_System_Config.ShowDoorHealth then draw.SimpleText( "Heath: " .. ent:Health(), "DoorFont", ScrW() / 2, ScrH() / 2 + 40, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER ) end
 		if DoorGroups and DoorGroups[game.GetMap()] and DoorGroups[game.GetMap()][entindex] then
 			draw.SimpleText( "Door Group: "..doorgroups.Name, "DoorFont", ScrW() / 2, ScrH() / 2 + 40, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
 		end

--- a/lua/autorun/client/cl_doors.lua
+++ b/lua/autorun/client/cl_doors.lua
@@ -200,7 +200,8 @@ OpenDoorMenuAdmin = function( ply, door, adminlimited)
 
 	if not adminlimited then OpenMenuBasics( menu, ply, door ) end
 
-	local adminSettingsOffset = 100
+	local adminSettingsOffset = 0
+	if adminlimited then adminSettingsOffset = 100 end
 
 	local adminlabel = Label( "Admin Settings", menu )
 	adminlabel:SetSize( 190, 15 )
@@ -374,7 +375,7 @@ hook.Add( "HUDPaint", "DoorHUD", function()
 	local keyname = language.GetPhrase( input.GetKeyName( GetConVar( "DoorKey" ):GetInt() ) )
 	local validdoor = Door_System_Config.AllowedDoors[entclass]
 	local adminonlydoor = not validdoor and DOOR_CONFIG_ADMIN_CAN_ALWAYS_CONFIGURE[entclass] and DOOR_CONFIG_ADMIN_RANKS[ply:GetUserGroup()]
-	print(tostring(validdoor))
+
 	if IsValid( ent ) and ply:GetPos():DistToSqr( ent:GetPos() ) < distance and (validdoor or adminonlydoor) then
 		if doorname != "" then
 			draw.SimpleText( doorname, "DoorFont", ScrW() / 2, ScrH() / 2 - 20, DOOR_CONFIG_NAME_COLOR, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )

--- a/lua/autorun/client/cl_doors.lua
+++ b/lua/autorun/client/cl_doors.lua
@@ -51,9 +51,9 @@ local function SetDoorName( ply, door )
 	end
 end
 
-local function CheckMenuAccess( ply, door )
+local function CheckMenuAccess( ply, door, adminlimited)
 	if DOOR_CONFIG_ADMIN_RANKS[ply:GetUserGroup()] then
-		OpenDoorMenuAdmin( ply, door )
+		OpenDoorMenuAdmin( ply, door, adminlimited or false)
 	else
 		OpenDoorMenu( ply, door )
 	end
@@ -184,7 +184,7 @@ local function OpenMenuBasics( menu, ply, door )
 	end
 end
 
-OpenDoorMenuAdmin = function( ply, door )
+OpenDoorMenuAdmin = function( ply, door, adminlimited)
 	local entindex = door:EntIndex()
 	local menu = vgui.Create( "DFrame" )
 	menu:SetTitle( "Door Settings" )
@@ -198,29 +198,31 @@ OpenDoorMenuAdmin = function( ply, door )
 		ply.MenuOpen = false
 	end
 
-	OpenMenuBasics( menu, ply, door )
+	if not adminlimited then OpenMenuBasics( menu, ply, door ) end
+
+	local adminSettingsOffset = 100
 
 	local adminlabel = Label( "Admin Settings", menu )
 	adminlabel:SetSize( 190, 15 )
-	adminlabel:SetPos( 70, 190 )
-
-	local sellbutton = vgui.Create( "DButton", menu )
-	sellbutton:SetText( "Force Remove Ownership" )
-	sellbutton:SetTextColor( DOOR_CONFIG_BUTTON_TEXT_COLOR )
-	sellbutton:SetPos( 30, 210 )
-	sellbutton:SetSize( 190, 30 )
-	sellbutton:CenterHorizontal()
-	sellbutton.Paint = function( self, w, h )
-		draw.RoundedBox( 0, 0, 0, w, h, DOOR_CONFIG_BUTTON_COLOR )
+	adminlabel:SetPos( 70, 190 - adminSettingsOffset)
+	if not adminlimited then
+		local sellbutton = vgui.Create( "DButton", menu )
+		sellbutton:SetText( "Force Remove Ownership" )
+		sellbutton:SetTextColor( DOOR_CONFIG_BUTTON_TEXT_COLOR )
+		sellbutton:SetPos( 30, 210  - adminSettingsOffset)
+		sellbutton:SetSize( 190, 30 )
+		sellbutton:CenterHorizontal()
+		sellbutton.Paint = function( self, w, h )
+			draw.RoundedBox( 0, 0, 0, w, h, DOOR_CONFIG_BUTTON_COLOR )
+		end
+		sellbutton.DoClick = function()
+			net.Start( "UnownDoor" )
+			net.WriteEntity( door )
+			net.WriteBool( true )
+			net.SendToServer()
+			menu:Close()
+		end
 	end
-	sellbutton.DoClick = function()
-		net.Start( "UnownDoor" )
-		net.WriteEntity( door )
-		net.WriteBool( true )
-		net.SendToServer()
-		menu:Close()
-	end
-
 	local restrictbutton = vgui.Create( "DButton", menu )
 	if DoorTable[entindex] then
 		restrictbutton:SetText( "Change Restriction" )
@@ -228,7 +230,7 @@ OpenDoorMenuAdmin = function( ply, door )
 		restrictbutton:SetText( "Add Restriction" )
 	end
 	restrictbutton:SetTextColor( DOOR_CONFIG_BUTTON_TEXT_COLOR )
-	restrictbutton:SetPos( 30, 250 )
+	restrictbutton:SetPos( 30, 250 - adminSettingsOffset)
 	restrictbutton:SetSize( 190, 30 )
 	restrictbutton:CenterHorizontal()
 	restrictbutton.Paint = function( self, w, h )
@@ -236,7 +238,7 @@ OpenDoorMenuAdmin = function( ply, door )
 	end
 	restrictbutton.DoClick = function()
 		local joblist = vgui.Create( "DComboBox", menu )
-		joblist:SetPos( 30, 255 )
+		joblist:SetPos( 30, 255 - adminSettingsOffset)
 		joblist:SetSize( 190, 20 )
 		joblist:CenterHorizontal()
 		joblist:SetValue( "Select Restriction" )
@@ -257,7 +259,7 @@ OpenDoorMenuAdmin = function( ply, door )
 	local restrictremove = vgui.Create( "DButton", menu )
 	restrictremove:SetText( "Remove Restriction" )
 	restrictremove:SetTextColor( DOOR_CONFIG_BUTTON_TEXT_COLOR )
-	restrictremove:SetPos( 30, 290 )
+	restrictremove:SetPos( 30, 290 - adminSettingsOffset)
 	restrictremove:SetSize( 190, 30 )
 	restrictremove:CenterHorizontal()
 	restrictremove.Paint = function( self, w, h )
@@ -283,7 +285,7 @@ OpenDoorMenuAdmin = function( ply, door )
 		local forcelock = vgui.Create( "DButton", menu )
 		forcelock:SetText( "Disable Force Lock" )
 		forcelock:SetTextColor( DOOR_CONFIG_BUTTON_TEXT_COLOR )
-		forcelock:SetPos( 30, 330 )
+		forcelock:SetPos( 30, 330 - adminSettingsOffset)
 		forcelock:SetSize( 190, 30 )
 		forcelock:CenterHorizontal()
 		forcelock.Paint = function( self, w, h )
@@ -304,7 +306,7 @@ OpenDoorMenuAdmin = function( ply, door )
 		local forcelock = vgui.Create( "DButton", menu )
 		forcelock:SetText( "Force Lock Door" )
 		forcelock:SetTextColor( DOOR_CONFIG_BUTTON_TEXT_COLOR )
-		forcelock:SetPos( 30, 330 )
+		forcelock:SetPos( 30, 330 - adminSettingsOffset)
 		forcelock:SetSize( 190, 30 )
 		forcelock:CenterHorizontal()
 		forcelock.Paint = function( self, w, h )
@@ -363,31 +365,38 @@ end
 local color_red = DOOR_CONFIG_TEXT_COLOR
 hook.Add( "HUDPaint", "DoorHUD", function()
 	local ply = LocalPlayer()
+	if ply.MenuOpen then return end
 	local ent = ply:GetEyeTrace().Entity
 	local doorowner = ent:GetNWEntity( "DoorOwner" )
 	local doorname = ent:GetNWString( "DoorName" )
 	local entindex = ent:EntIndex()
+	local entclass = ent:GetClass()
 	local keyname = language.GetPhrase( input.GetKeyName( GetConVar( "DoorKey" ):GetInt() ) )
-	if ply.MenuOpen then return end
-	if IsValid( ent ) and ply:GetPos():DistToSqr( ent:GetPos() ) < distance and Door_System_Config.AllowedDoors[ent:GetClass()] then
+	local validdoor = Door_System_Config.AllowedDoors[entclass]
+	local adminonlydoor = not validdoor and DOOR_CONFIG_ADMIN_CAN_ALWAYS_CONFIGURE[entclass] and DOOR_CONFIG_ADMIN_RANKS[ply:GetUserGroup()]
+	print(tostring(validdoor))
+	if IsValid( ent ) and ply:GetPos():DistToSqr( ent:GetPos() ) < distance and (validdoor or adminonlydoor) then
 		if doorname != "" then
 			draw.SimpleText( doorname, "DoorFont", ScrW() / 2, ScrH() / 2 - 20, DOOR_CONFIG_NAME_COLOR, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
 		end
-		if IsValid( doorowner) and DoorCoOwners[entindex] and !table.IsEmpty( DoorCoOwners[entindex] ) then
-			draw.SimpleText( "Owners: "..doorowner:Nick()..ListCoOwners( entindex ), "DoorFont", ScrW() / 2, ScrH() / 2, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
-		else
-			if IsValid( doorowner ) then
-				draw.SimpleText( "Owner: "..doorowner:Nick(), "DoorFont", ScrW() / 2, ScrH() / 2, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
+		if not adminonlydoor then
+			if IsValid( doorowner) and DoorCoOwners[entindex] and !table.IsEmpty( DoorCoOwners[entindex] ) then
+				draw.SimpleText( "Owners: "..doorowner:Nick()..ListCoOwners( entindex ), "DoorFont", ScrW() / 2, ScrH() / 2, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
 			else
-				if DoorTable[entindex] then
-					draw.SimpleText( "Owner: "..GetDoorRestrictions( entindex ), "DoorFont", ScrW() / 2, ScrH() / 2, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
+				if IsValid( doorowner ) then
+					draw.SimpleText( "Owner: "..doorowner:Nick(), "DoorFont", ScrW() / 2, ScrH() / 2, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
 				else
-					draw.SimpleText( "Owner: None", "DoorFont", ScrW() / 2, ScrH() / 2, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
+					if DoorTable[entindex] then
+						draw.SimpleText( "Owner: "..GetDoorRestrictions( entindex ), "DoorFont", ScrW() / 2, ScrH() / 2, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
+					else
+						draw.SimpleText( "Owner: None", "DoorFont", ScrW() / 2, ScrH() / 2, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
+					end
 				end
 			end
+		else draw.SimpleText( "Admin Only Door", "DoorFont", ScrW() / 2, ScrH() / 2, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
 		end
 		draw.SimpleText( "Press "..keyname.." for door options.", "DoorFont", ScrW() / 2, ScrH() / 2 + 20, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
-		if Door_System_Config.ShowDoorHealth then draw.SimpleText( "Heath: " .. ent:Health(), "DoorFont", ScrW() / 2, ScrH() / 2 + 40, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER ) end
+		if not adminonlydoor and Door_System_Config.ShowDoorHealth then draw.SimpleText( "Heath: " .. ent:Health(), "DoorFont", ScrW() / 2, ScrH() / 2 + 40, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER ) end
 		if DoorGroups and DoorGroups[game.GetMap()] and DoorGroups[game.GetMap()][entindex] then
 			draw.SimpleText( "Door Group: "..doorgroups.Name, "DoorFont", ScrW() / 2, ScrH() / 2 + 40, color_red, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
 		end
@@ -397,9 +406,14 @@ end )
 hook.Add( "PlayerButtonDown", "DoorButtons", function( ply, button )
 	local doorkey = GetConVar( "DoorKey" ):GetInt()
 	local ent = ply:GetEyeTrace().Entity
+	local entclass = ent:GetClass()
 	if !IsFirstTimePredicted() or ply.MenuOpen then return end
-	if IsValid( ent ) and button == doorkey and ply:GetPos():DistToSqr( ent:GetPos() ) < distance and Door_System_Config.AllowedDoors[ent:GetClass()] then
-		CheckMenuAccess( ply, ent )
+	if IsValid( ent ) and button == doorkey and ply:GetPos():DistToSqr( ent:GetPos() ) < distance then
+		if Door_System_Config.AllowedDoors[entclass] then
+			CheckMenuAccess(ply, ent)
+		elseif (DOOR_CONFIG_ADMIN_CAN_ALWAYS_CONFIGURE[entclass] and DOOR_CONFIG_ADMIN_RANKS[ply:GetUserGroup()]) then
+			CheckMenuAccess(ply, ent, true)
+		end
 	end
 end )
 

--- a/lua/autorun/doors_config.lua
+++ b/lua/autorun/doors_config.lua
@@ -81,6 +81,12 @@ DOOR_CONFIG_ADMIN_RANKS = { --The ranks that have permission to edit door owners
     --["admin"] = true,
 }
 
+//Enter the entities you want admins always to have access to. For example, if you don't want users to manage "func_door"
+DOOR_CONFIG_ADMIN_CAN_ALWAYS_CONFIGURE = { -- but you want admins to manage them, then put the entity class here.
+	--["func_door"] = true,
+	--["func_door_rotating"] = true,
+}
+
 DOOR_CONFIG_ALLOWED_DOOR_AMOUNT = 0 --How many doors the player may have at any time. If 0, you can own unlimited
 
 

--- a/lua/autorun/doors_config.lua
+++ b/lua/autorun/doors_config.lua
@@ -84,19 +84,21 @@ DOOR_CONFIG_ALLOWED_DOOR_AMOUNT = 0 --How many doors the player may have at any 
 //Choose one by removing or adding --
 local function DOOR_CONFIG_PRICE_CHECK(ply, price) price = price or DOOR_CONFIG_PRICE return
 	((ply:getDarkRPVar("money") or 0) >= price) //DarkRP
-	--(ply:getChar():hasMoney(price)) //Nut Script
-	--((ply:GetMoney() or 0) >= price) //BaseWars
-	--ply:SH_CanAffordStandard(price) //SH Pointshop
-	--ply:PS_HasPoints(price) //Pointshop
+	--(ply:getChar():hasMoney(price))             //Nut Script
+	--((ply:GetMoney() or 0) >= price)            //BaseWars
+	--ply:SH_CanAffordStandard(price)             //SH Pointshop
+	--ply:PS_HasPoints(price)                     //Pointshop
+	--true                                        //Sandbox
 end
 
 //Choose one by removing or adding --
+//For no currency, be sure to have -- in front of all currencies below
 local function DOOR_CONFIG_PURCHASE(ply, price) price = price or DOOR_CONFIG_PRICE 
-	ply:addMoney(-price) //DarkRP
-	--ply:getChar():takeMoney(price) //Nut Script
-	--ply:GiveMoney(-price) //BaseWars
+	ply:addMoney(-price)             //DarkRP
+	--ply:getChar():takeMoney(price)   //Nut Script
+	--ply:GiveMoney(-price)            //BaseWars
 	--ply:SH_AddStandardPoints(-price) //SH Pointshop
-	--ply:PS_TakePoints(price) //Pointshop
+	--ply:PS_TakePoints(price)         //Pointshop
 end
 
 local function OWN_MESSAGE(ply)
@@ -121,7 +123,8 @@ DOOR_CONFIG_MESSAGES = {
 	["Sold All"] = "You have sold all of your doors.",
 	["Ran Out of Doors"] = "You ran out of doors! Remove a door or remove all doors with " .. DOOR_CONFIG_COMMANDS["Sell All"],
 	["No Doors Owned"] = "You do not own any doors.",
-	["Door Sold"] = "You have sold this door."
+	["Door Sold"] = "You have sold this door.",
+	["Door Locked"] = "This door is locked ..."
 }
 
 

--- a/lua/autorun/doors_config.lua
+++ b/lua/autorun/doors_config.lua
@@ -76,7 +76,10 @@ DOOR_CONFIG_BUTTON_TEXT_COLOR = color_white --Color of the text on the buttons
 
 DOOR_CONFIG_DISTANCE = 100 --Max distance in hammer units away from a door where players can interact with it
 
-DOOR_CONFIG_ALLOW_ADMIN = false --Whether or not admins should be able to edit door ownerships alongside superadmins
+DOOR_CONFIG_ADMIN_RANKS = { --The ranks that have permission to edit door ownerships. CAPS COUNT
+    ["superadmin"] = true,
+    --["admin"] = true,
+}
 
 DOOR_CONFIG_ALLOWED_DOOR_AMOUNT = 0 --How many doors the player may have at any time. If 0, you can own unlimited
 

--- a/lua/autorun/doors_config.lua
+++ b/lua/autorun/doors_config.lua
@@ -78,7 +78,7 @@ DOOR_CONFIG_DISTANCE = 100 --Max distance in hammer units away from a door where
 
 DOOR_CONFIG_ALLOW_ADMIN = false --Whether or not admins should be able to edit door ownerships alongside superadmins
 
-DOOR_CONFIG_ALLOWED_DOOR_AMOUNT = 3 --How many doors the player may have at any time. If 0, you can own unlimited
+DOOR_CONFIG_ALLOWED_DOOR_AMOUNT = 0 --How many doors the player may have at any time. If 0, you can own unlimited
 
 
 //Choose one by removing or adding --

--- a/lua/autorun/doors_config.lua
+++ b/lua/autorun/doors_config.lua
@@ -1,6 +1,7 @@
-
 DoorRestrictions = {} --Initializes the door restrictions table, don't touch
 DoorGroups = {}
+DoorFunctions = {}
+PlayerDoors = {}
 
 --[[
 	Below are the configs for the door restrictions. Each table includes
@@ -56,7 +57,8 @@ DoorRestrictions[2] = {
 
 DOOR_CONFIG_PRICE = 30 --Price players pay for the doors (DarkRP only)
 
-DOOR_CONFIG_CHARGE_EXTRA = false --Whether or not players should be charged for each door in a group (DarkRP only)
+DOOR_CONFIG_DOOR_GROUPS_ENABLED = true -- May not work with door amount at the moment
+	DOOR_CONFIG_CHARGE_EXTRA = false --Whether or not players should be charged for each door in a group (DarkRP only)
 
 DOOR_CONFIG_REQUIRE_WARRANT = true --Whether or not cops need a warrant to force open doors with the battering ram (DarkRP only)
 
@@ -75,3 +77,54 @@ DOOR_CONFIG_BUTTON_TEXT_COLOR = color_white --Color of the text on the buttons
 DOOR_CONFIG_DISTANCE = 100 --Max distance in hammer units away from a door where players can interact with it
 
 DOOR_CONFIG_ALLOW_ADMIN = false --Whether or not admins should be able to edit door ownerships alongside superadmins
+
+DOOR_CONFIG_ALLOWED_DOOR_AMOUNT = 3 --How many doors the player may have at any time. If 0, you can own unlimited
+
+
+//Choose one by removing or adding --
+local function DOOR_CONFIG_PRICE_CHECK(ply, price) price = price or DOOR_CONFIG_PRICE return
+	((ply:getDarkRPVar("money") or 0) >= price) //DarkRP
+	--(ply:getChar():hasMoney(price)) //Nut Script
+	--((ply:GetMoney() or 0) >= price) //BaseWars
+	--ply:SH_CanAffordStandard(price) //SH Pointshop
+	--ply:PS_HasPoints(price) //Pointshop
+end
+
+//Choose one by removing or adding --
+local function DOOR_CONFIG_PURCHASE(ply, price) price = price or DOOR_CONFIG_PRICE 
+	ply:addMoney(-price) //DarkRP
+	--ply:getChar():takeMoney(price) //Nut Script
+	--ply:GiveMoney(-price) //BaseWars
+	--ply:SH_AddStandardPoints(-price) //SH Pointshop
+	--ply:PS_TakePoints(price) //Pointshop
+end
+
+local function OWN_MESSAGE(ply)
+	if DOOR_CONFIG_ALLOWED_DOOR_AMOUNT > 0 then return DOOR_CONFIG_MESSAGES["Purchase Successful"] .. 
+	"You have " .. tostring(DOOR_CONFIG_ALLOWED_DOOR_AMOUNT - PlayerDoors[ply]) .. " doors remaining." end
+	return DOOR_CONFIG_MESSAGES["Purchase Successful"]
+end
+
+DOOR_CONFIG_COMMANDS = {
+	["Sell All"] = "/sellalldoors"
+}
+
+DOOR_CONFIG_MESSAGES = {
+	["Managed By Another Group"] = "This door is managed by a group and cannot be owned.",
+	["Already Owned"] = "This door is already owned by someone else.",
+	["Do Not Own"] = "You do not own this door.",
+	["Cannot Afford"] = "You can't afford to buy this door.",
+	["Purchase Successful"] = "You now own this door.",
+	["Own Of All of Group"] = "You also now own all of the doors in the ", -- doorgroupName door group.
+	["Override Successful"] = "Door ownership override successful.",
+	["Sold From Group"] = "You have also sold all of the doors in the ", -- doorgroupName door group.
+	["Sold All"] = "You have sold all of your doors.",
+	["Ran Out of Doors"] = "You ran out of doors! Remove a door or remove all doors with " .. DOOR_CONFIG_COMMANDS["Sell All"],
+	["No Doors Owned"] = "You have sold all of your doors."
+}
+
+
+-------------------don't touch----------------------
+DoorFunctions.DOOR_PRICE_CHECK = DOOR_CONFIG_PRICE_CHECK
+DoorFunctions.DOOR_PURCHASE = DOOR_CONFIG_PURCHASE
+DoorFunctions.OWN_MESSAGE = OWN_MESSAGE

--- a/lua/autorun/doors_config.lua
+++ b/lua/autorun/doors_config.lua
@@ -101,7 +101,7 @@ end
 
 local function OWN_MESSAGE(ply)
 	if DOOR_CONFIG_ALLOWED_DOOR_AMOUNT > 0 then return DOOR_CONFIG_MESSAGES["Purchase Successful"] .. 
-	"You have " .. tostring(DOOR_CONFIG_ALLOWED_DOOR_AMOUNT - PlayerDoors[ply]) .. " doors remaining." end
+	" You have " .. tostring(DOOR_CONFIG_ALLOWED_DOOR_AMOUNT - PlayerDoors[ply]) .. " doors remaining." end
 	return DOOR_CONFIG_MESSAGES["Purchase Successful"]
 end
 
@@ -120,7 +120,8 @@ DOOR_CONFIG_MESSAGES = {
 	["Sold From Group"] = "You have also sold all of the doors in the ", -- doorgroupName door group.
 	["Sold All"] = "You have sold all of your doors.",
 	["Ran Out of Doors"] = "You ran out of doors! Remove a door or remove all doors with " .. DOOR_CONFIG_COMMANDS["Sell All"],
-	["No Doors Owned"] = "You have sold all of your doors."
+	["No Doors Owned"] = "You do not own any doors.",
+	["Door Sold"] = "You have sold this door."
 }
 
 

--- a/lua/autorun/server/sv_doors.lua
+++ b/lua/autorun/server/sv_doors.lua
@@ -265,7 +265,7 @@ net.Receive( "SyncCoOwner", function( len, sender )
 	local remove = net.ReadBool()
 	local door = ents.GetByIndex( index )
 	if DoorTable[index] then
-		DS_Notify( sender, "This door is locked ..." )
+		DS_Notify( sender, DOOR_CONFIG_MESSAGES["Managed By Another Group"] )
 		return
 	end
 	if remove then

--- a/lua/gmodadminsuite/modules/logging/modules/door_logging.lua
+++ b/lua/gmodadminsuite/modules/logging/modules/door_logging.lua
@@ -1,0 +1,44 @@
+local function GetEntityPosRounded(ent)
+	local v = ent:GetPos()
+	return {
+		x = math.Round(v.x),
+		y = math.Round(v.y),
+		z = math.Round(v.z)
+	}
+end
+
+local function GetEntityPosRoundedString(ent)
+	v = GetEntityPosRounded(ent)
+	x = v.x
+	y = v.y
+	z = v.z
+	return "X: " .. x .. ", Y: " .. y .. ", Z: " .. z
+end
+
+local DOOR_PURCHASE = GAS.Logging:MODULE()
+
+DOOR_PURCHASE.Category = "Door System"
+DOOR_PURCHASE.Name     = "Door Purchased"
+DOOR_PURCHASE.Colour   = Color(254, 89, 0)
+
+DOOR_PURCHASE:Setup(function()
+	DOOR_PURCHASE:Hook("Door_System_Purchase", "OnDoorPurchase", function(ply, ent, price)
+		DOOR_PURCHASE:Log("{1} purchased door: {2} at {3} for {4}", GAS.Logging:FormatPlayer(ply), GAS.Logging:FormatProp(ent), GAS.Logging:Highlight(GetEntityPosRoundedString(ent)), GAS.Logging:FormatMoney(price)) 
+	end)
+end)
+
+GAS.Logging:AddModule(DOOR_PURCHASE)
+
+local DOOR_SELL = GAS.Logging:MODULE()
+
+DOOR_SELL.Category = "Door System"
+DOOR_SELL.Name     = "Door Sold"
+DOOR_SELL.Colour   = Color(254, 89, 0)
+
+DOOR_SELL:Setup(function()
+	DOOR_SELL:Hook("Door_System_Sell", "OnDoorSell", function(ply, ent)
+		DOOR_SELL:Log("{1} sold door: {2} at {3}", GAS.Logging:FormatPlayer(ply), GAS.Logging:FormatProp(ent), GAS.Logging:Highlight(GetEntityPosRoundedString(ent)))
+	end)
+end)
+
+GAS.Logging:AddModule(DOOR_SELL)


### PR DESCRIPTION
You can now edit the messages as well as what currency system you plan to use.

New options:
DOOR_CONFIG_DOOR_GROUPS_ENABLED = true -- May not work with door amount at the moment

DOOR_CONFIG_ALLOWED_DOOR_AMOUNT = 3 --How many doors the player may have at any time. If 0, you can own unlimited

Added a way to change the command within the command.

All currencies are supported, but DarkRP, Nut Script, BaseWars, SH Pointshop, & Pointshop are added by default.

THESE CHANGES MOSTLY WORK.
NOT ALL WAS TESTED. PLEASE TEST AND FIX ANYTHING RELATED TO DARK RP!!!